### PR TITLE
Fix bad backslash escape usage.

### DIFF
--- a/vobject/base.py
+++ b/vobject/base.py
@@ -733,7 +733,7 @@ patterns = {}
 
 # Note that underscore is not legal for names, it's included because
 # Lotus Notes uses it
-patterns['name'] = '[a-zA-Z0-9\-_]+'
+patterns['name'] = '[a-zA-Z0-9_-]+'   # 1*(ALPHA / DIGIT / "-")
 patterns['safe_char'] = '[^";:,]'
 patterns['qsafe_char'] = '[^"]'
 
@@ -1216,5 +1216,5 @@ def newFromBehavior(name, id=None):
 
 # --------------------------- Helper function ----------------------------------
 def backslashEscape(s):
-    s = s.replace("\\", "\\\\").replace(";", "\;").replace(",", "\,")
+    s = s.replace("\\", "\\\\").replace(";", "\\;").replace(",", "\\,")
     return s.replace("\r\n", "\\n").replace("\n", "\\n").replace("\r", "\\n")


### PR DESCRIPTION
Python 3.6 began reporting a DeprecationWarning for the use of backslash escape sequence where the second character isn't a valid Python escape sequence.  Unlike C, in Python, the result of this is both characters (not just the second).

Python 3.12 changed that to a SyntaxWarning, the final step before making it a SyntaxError.  So, we should fix it now.

First reported as https://github.com/eventable/vobject/issues/164