### PR TITLE
Removed PyICU dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ VObject is licensed under the [Apache 2.0 license](http://www.apache.org/license
 Useful scripts included with VObject:
 
 * [ics_diff](https://github.com/py-vobject/vobject/blob/master/vobject/ics_diff.py): order is irrelevant in iCalendar files, return a diff of meaningful changes between icalendar files
-* [change_tz](https://github.com/py-vobject/vobject/blob/master/vobject/change_tz.py): Take an iCalendar file with events in the wrong timezone, change all events or just UTC events into one of the timezones PyICU supports. Requires [PyICU](https://pypi.python.org/pypi/PyICU/).
+* [change_tz](https://github.com/py-vobject/vobject/blob/master/vobject/change_tz.py): Take an iCalendar file with events in the wrong timezone, change all events or just UTC events into one of the timezones **pytz** supports. Requires [pytz](https://pypi.python.org/pypi/pytz/).
 
 # History
 VObject was originally developed in concert with the Open Source Application 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-python-dateutil >= 2.8.0
-pytz~=2024.1
+python-dateutil >= 2.5.0; python_version < '3.10'
+python-dateutil >= 2.7.0; python_version >= '3.10'
+pytz>=2019.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-python-dateutil >= 2.4.0
+python-dateutil >= 2.8.0
+pytz~=2024.1

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,9 @@ setup(name = "vobject",
             ]
       },
       include_package_data = True,
-      install_requires = ['python-dateutil >= 2.4.0', 'six'],
+      install_requires=["python-dateutil >= 2.5.0; python_version < '3.10'",
+                        "python-dateutil >= 2.7.0; python_version >= '3.10'",
+                        "pytz", 'six'],
       platforms = ["any"],
       packages = find_packages(),
       description = "A full-featured Python package for parsing and creating "

--- a/vobject/change_tz.py
+++ b/vobject/change_tz.py
@@ -41,16 +41,16 @@ def show_timezones():
 
 
 def convert_events(utc_only, args):
-    print(f"Converting {'only UTC' if utc_only else 'all'} events")
+    print("Converting {} events".format('only UTC' if utc_only else 'all'))
     ics_file = args[0]
     _tzone = args[1] if len(args) > 1 else 'UTC'
 
-    print(f"... Reading {ics_file}")
+    print("... Reading {}".format(ics_file))
     cal = base.readOne(open(ics_file))
     change_tz(cal, new_timezone=tz.gettz(_tzone), default=tz.gettz('UTC'), utc_only=utc_only)
 
-    out_name = f"{ics_file}.converted"
-    print(f"... Writing {out_name}")
+    out_name = "{}.converted".format(ics_file)
+    print("... Writing {}".format(out_name))
     with open(out_name, 'wb') as out:
         cal.serialize(out)
 

--- a/vobject/change_tz.py
+++ b/vobject/change_tz.py
@@ -1,14 +1,14 @@
 """Translate an ics file's events to a different timezone."""
 
 from optparse import OptionParser
+
+import pytz
+from dateutil import tz
+
 from vobject import icalendar, base
+from datetime import datetime, tzinfo
 
-try:
-    import PyICU
-except:
-    PyICU = None
-
-from datetime import datetime
+version = "0.1"
 
 
 def change_tz(cal, new_timezone, default, utc_only=False, utc_tz=icalendar.utc):
@@ -18,11 +18,9 @@ def change_tz(cal, new_timezone, default, utc_only=False, utc_tz=icalendar.utc):
     Args:
         cal (Component): the component to change
         new_timezone (tzinfo): the timezone to change to
-        default (tzinfo): a timezone to assume if the dtstart or dtend in cal
-            doesn't have an existing timezone
+        default (tzinfo): a timezone to assume if the dtstart or dtend in cal doesn't have an existing timezone
         utc_only (bool): only convert dates that are in utc
-        utc_tz (tzinfo): the tzinfo to compare to for UTC when processing
-            utc_only=True
+        utc_tz (tzinfo): the tzinfo to compare to for UTC when processing utc_only=True
     """
 
     for vevent in getattr(cal, 'vevent_list', []):
@@ -31,51 +29,45 @@ def change_tz(cal, new_timezone, default, utc_only=False, utc_tz=icalendar.utc):
         for node in (start, end):
             if node:
                 dt = node.value
-                if (isinstance(dt, datetime) and
-                        (not utc_only or dt.tzinfo == utc_tz)):
+                if isinstance(dt, datetime) and (not utc_only or dt.tzinfo == utc_tz):
                     if dt.tzinfo is None:
                         dt = dt.replace(tzinfo=default)
                     node.value = dt.astimezone(new_timezone)
 
 
+def show_timezones():
+    for tz_string in pytz.all_timezones:
+        print(tz_string)
+
+
+def convert_events(utc_only, args):
+    print(f"Converting {'only UTC' if utc_only else 'all'} events")
+    ics_file = args[0]
+    _tzone = args[1] if len(args) > 1 else 'UTC'
+
+    print(f"... Reading {ics_file}")
+    cal = base.readOne(open(ics_file))
+    change_tz(cal, new_timezone=tz.gettz(_tzone), default=tz.gettz('UTC'), utc_only=utc_only)
+
+    out_name = f"{ics_file}.converted"
+    print(f"... Writing {out_name}")
+    with open(out_name, 'wb') as out:
+        cal.serialize(out)
+
+    print("Done")
+
+
 def main():
     options, args = get_options()
-    if PyICU is None:
-        print("Failure. change_tz requires PyICU, exiting")
-    elif options.list:
-        for tz_string in PyICU.TimeZone.createEnumeration():
-            print(tz_string)
+
+    if options.list:
+        show_timezones()
     elif args:
-        utc_only = options.utc
-        if utc_only:
-            which = "only UTC"
-        else:
-            which = "all"
-        print("Converting {0!s} events".format(which))
-        ics_file = args[0]
-        if len(args) > 1:
-            timezone = PyICU.ICUtzinfo.getInstance(args[1])
-        else:
-            timezone = PyICU.ICUtzinfo.default
-        print("... Reading {0!s}".format(ics_file))
-        cal = base.readOne(open(ics_file))
-        change_tz(cal, timezone, PyICU.ICUtzinfo.default, utc_only)
-
-        out_name = ics_file + '.converted'
-        print("... Writing {0!s}".format(out_name))
-
-        with open(out_name, 'wb') as out:
-            cal.serialize(out)
-
-        print("Done")
-
-
-version = "0.1"
+        convert_events(utc_only=options.utc, args=args)
 
 
 def get_options():
     # Configuration options
-
     usage = """usage: %prog [options] ics_file [timezone]"""
     parser = OptionParser(usage=usage, version=version)
     parser.set_description("change_tz will convert the timezones in an ics file. ")
@@ -86,13 +78,13 @@ def get_options():
                       default=False, help="List available timezones")
 
     (cmdline_options, args) = parser.parse_args()
-    if not args and not cmdline_options.list:
+    if not (args or cmdline_options.list):
         print("error: too few arguments given")
-        print
         print(parser.format_help())
-        return False, False
+        return cmdline_options, False
 
     return cmdline_options, args
+
 
 if __name__ == "__main__":
     try:

--- a/vobject/change_tz.py
+++ b/vobject/change_tz.py
@@ -1,12 +1,12 @@
 """Translate an ics file's events to a different timezone."""
 
+from datetime import datetime
 from optparse import OptionParser
 
 import pytz
 from dateutil import tz
 
-from vobject import icalendar, base
-from datetime import datetime, tzinfo
+from vobject import base, icalendar
 
 version = "0.1"
 

--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -333,7 +333,7 @@ class TimezoneComponent(Component):
         if tzinfo is None or (not allowUTC and tzinfo_eq(tzinfo, utc)):
             # If tzinfo is UTC, we don't need a TZID
             return None
-        # try PyICU's tzid key
+        # try Pytz's tzid key
         if hasattr(tzinfo, 'tzid'):
             return toUnicode(tzinfo.tzid)
 


### PR DESCRIPTION
Issue : #35 

`PyICU` is only used for listing and parsing timezones, which can be replaced with `pytz` and `dateutil`.

**Checks**:
- [x]  All 42 testcases passed.

**Changes**: 
- PyICU functions are replaced with its equivalnet funcs `pytz.all_timezones` and `dateutil.tz.gettz()`, as used in tests.py.
- `main()` is split into 2 simpler functions.