### PR TITLE
Explicitly export types from __init__.py

### DIFF
--- a/vobject/__init__.py
+++ b/vobject/__init__.py
@@ -76,9 +76,13 @@ VObject Overview
 
 """
 
-from .base import newFromBehavior, readOne, readComponents
-from . import icalendar, vcard
-
+from . import (
+        icalendar as icalendar,
+        vcard as vcard)
+from .base import (
+        newFromBehavior,
+        readComponents as readComponents,
+        readOne as readOne)
 
 # Package version
 VERSION = "0.9.8"


### PR DESCRIPTION
Adds explicit import aliases per
https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport.

Fixes #53.