### PR TITLE
Fixes #62.

### DIFF
--- a/test_files/radicale-1587.vcf
+++ b/test_files/radicale-1587.vcf
@@ -1,0 +1,6 @@
+BEGIN:VCARD
+VERSION:3.0
+FN:Given Family
+N:Family;Given;Additional;Prefix;Suffix
+GEO:37.386013;-122.082932
+END:VCARD

--- a/tests.py
+++ b/tests.py
@@ -1022,6 +1022,16 @@ class TestCompatibility(unittest.TestCase):
             self.assertIsNotNone(vo)
         return
 
+    def test_radicale_1587(self):
+        vcf_str = get_test_file("radicale-1587.vcf")
+        vobjs = base.readComponents(vcf_str)
+        for vo in vobjs:
+            self.assertIsNotNone(vo)
+            lines = vo.serialize().split("\r\n")
+            for line in lines:
+                if line.startswith("GEO"):
+                    self.assertEqual(line, "GEO:37.386013;-122.082932")
+        return
 
 if __name__ == '__main__':
     unittest.main()

--- a/vobject/vcard.py
+++ b/vobject/vcard.py
@@ -180,7 +180,8 @@ class VCard3_0(VCardBehavior):
         'ADR':        (0, None, None),
         'ORG':        (0, None, None),
         'PHOTO':      (0, None, None),
-        'CATEGORIES': (0, None, None)
+        'CATEGORIES': (0, None, None),
+        'GEO':        (0, None, None)
     }
 
     @classmethod
@@ -206,6 +207,13 @@ class Label(VCardTextBehavior):
     name = "Label"
     description = 'Formatted address'
 registerBehavior(Label)
+
+
+class GEO(VCardBehavior):
+    name = "GEO"
+    description = "Geographical location"
+registerBehavior(GEO)
+
 
 wacky_apple_photo_serialize = True
 REALLY_LARGE = 1E50


### PR DESCRIPTION
Define a behaviour class for vCard 3.0 GEO lines, overriding the default VCardTextBehavior to avoid backslash-escaping the required semi-colon in GEO values.