### PR TITLE
Resolved tzinfo conflict in tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -703,7 +703,7 @@ class TestIcalendar(unittest.TestCase):
         def unregister_tzid(tzid):
             """Clear tzid from icalendar TZID registry"""
             if icalendar.getTzid(tzid, False):
-                icalendar.registerTzid(tzid, None)
+                icalendar.registerTzid(tzid, tzutc())
 
         unregister_tzid('US/Eastern')
         eastern = pytz.timezone('US/Eastern')


### PR DESCRIPTION
Fixes #73 

Default `tzinfo = tzutc()`, before running `test_pytz_timezone_serializing`.
So same value is set in unregister function.