### PR TITLE
Include missing *.vcf test files in sdist (0.9.x)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include README.md ACKNOWLEDGEMENTS.txt LICENSE-2.0.txt tests.py
-recursive-include test_files *.ics
+recursive-include test_files *.ics *.vcf


### PR DESCRIPTION
Otherwise tests fail:

```
======================================================================
ERROR: test_radicale_1587 (tests.TestCompatibility)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/portage/dev-python/vobject-0.9.9/work/vobject-0.9.9/tests.py", line 1026, in test_radicale_1587
    vcf_str = get_test_file("radicale-1587.vcf")
  File "/tmp/portage/dev-python/vobject-0.9.9/work/vobject-0.9.9/tests.py", line 43, in get_test_file
    f = open(filepath, 'r', encoding='utf-8')
FileNotFoundError: [Errno 2] No such file or directory: 'test_files/radicale-1587.vcf'

----------------------------------------------------------------------
```