### PR TITLE
Change unit test to use "America/New_York" time zone name.

### DIFF
--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -549,11 +549,11 @@ def test_omits_dst_offset():
     # Check dateutil, pytz, and zoneinfo (3.9+) tzinfo instances
     _timezones = []
     if "dateutil" in globals():
-        tz = dateutil.tz.gettz("US/Eastern")
+        tz = dateutil.tz.gettz("America/New_York")
         assert tz is not None
         _timezones.append(tz)
     if "zoneinfo" in globals():
-        tz = zoneinfo.ZoneInfo("US/Eastern")
+        tz = zoneinfo.ZoneInfo("America/New_York")
         assert tz is not None
         _timezones.append(tz)
 


### PR DESCRIPTION
Ubuntu 24.10 (at least) has removed the "US/*" time zone names from the installed zoneinfo database: the files are now available through a supplementary package, "tzdata-legacy", but it is not installed by default.

To avoid confusing, pointless, breakage, switch to using the "America/New_York" name, which is (thus far) universally available, but semantically identical.