### PR TITLE
Fix non-unique TZID when using zoneinfo-derived tzinfo's.

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -335,6 +335,10 @@ class TimezoneComponent(Component):
         if tzinfo is None or (not allowUTC and tzinfo_eq(tzinfo, utc)):
             return None
 
+        # Try a zoneinfo (CPython 3.9+) first.
+        if hasattr(tzinfo, 'key'):
+            return toUnicode(tzinfo.key)
+
         # Try pytz tzid key
         if hasattr(tzinfo, 'tzid'):
             return toUnicode(tzinfo.tzid)


### PR DESCRIPTION
Add support for getting unique TZID values from `zoneinfo.ZoneInfo` instances.