### PR TITLE
Dropped support for py3.8 and added for py3.14

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5.1.1
+      - uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: "3.10"
           cache: 'pip'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 7.0.0
     hooks:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.9.0
     hooks:
       - id: black
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: check-toml
@@ -19,7 +19,7 @@ repos:
         args: [ -b, main, -b, master ]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         additional_dependencies: [ flake8-pyproject ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "python-dateutil >= 2.7.0; python_version >= '3.10'",
     "pytz >= 2019.1",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 authors = [
      {name = "Jeffrey Harris", email = "jeffrey@osafoundation.org"},
 ]
@@ -29,12 +29,12 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Text Processing",
 ]
 
@@ -97,7 +97,7 @@ multi_line_output = 3
 
 [tool.tox]
 requires = ["tox>=4.19"]
-env_list = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+env_list = ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.tox.env_run_base]
 description = "Run test under {base_python}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import subprocess
-from typing import List
 
 
 class Cli:
@@ -7,7 +6,7 @@ class Cli:
     change_tz = "change_tz"
 
 
-def run_cli_tool(toolname: str, args: List[str]):
+def run_cli_tool(toolname: str, args: list[str]):
     return subprocess.run([toolname] + args, capture_output=True, text=True, check=False)
 
 

--- a/tests/test_icalendar.py
+++ b/tests/test_icalendar.py
@@ -1,18 +1,12 @@
 import datetime
 import io
 import re
+import zoneinfo
 
 import dateutil
 import pytest
 
 import vobject
-
-# Only available from CPython 3.9 onwards
-try:
-    import zoneinfo
-except ImportError:
-    pass
-
 
 timezones = (
     "BEGIN:VTIMEZONE\r\n"
@@ -552,10 +546,11 @@ def test_omits_dst_offset():
         tz = dateutil.tz.gettz("America/New_York")
         assert tz is not None
         _timezones.append(tz)
-    if "zoneinfo" in globals():
-        tz = zoneinfo.ZoneInfo("America/New_York")
-        assert tz is not None
-        _timezones.append(tz)
+
+    # zoneinfo
+    tz = zoneinfo.ZoneInfo("America/New_York")
+    assert tz is not None
+    _timezones.append(tz)
 
     for tz in _timezones:
         dt = datetime.datetime(2020, 1, 1)


### PR DESCRIPTION
## Python Releases
https://devguide.python.org/versions/
- 3.14 is released on 7th Oct 2025
- 3.8 reached EOL on 7th Oct 2024

## Changes
- Simplified/removed 3.8 compatibility code
- Upgraded GitHub action and linter versions to support py3.14
- Updated `pyproject.toml` to use py3.9 as base version