### PR TITLE
Ignore un-escaped commas when parsing single-value properties

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -693,7 +693,7 @@ class TextBehavior(behavior.Behavior):
             if encoding and encoding.upper() == cls.base64string:
                 line.value = base64.b64decode(line.value)
             else:
-                line.value = stringToTextValues(line.value)[0]
+                line.value = stringToTextValues(line.value, listSeparator=None)[0]
             line.encoded = False
 
     @classmethod


### PR DESCRIPTION
Some non-conformant implementations of RFC 5545 (namely PRODID:-//Microsoft Corporation//Outlook MIMEDIR//EN) fail to escape COMMA characters in text property values. For instance,

  DESCRIPTION:Hi Laurent,\nYou have been requested to meet with [...]

The COMMA character is used to delimitate values in multi-value properties, and must be escaped according to the RFC when a literal comma is needed. When parsing the above DESCRIPTION property, vobject returns "Hi Laurent" as the property value.

Ignoring un-escaped comas in properties defined as accepting a single value should be safe. Fortunately, vobject marks those properties by associating them with TextBehaviour. We can simply change the behaviour to not use the comma as a list separator.

Closes: #55