### PR TITLE
Raise ParseError, not StopIteration, from readOne on an empty stream

### DIFF
--- a/tests/test_vobject_parsing.py
+++ b/tests/test_vobject_parsing.py
@@ -143,6 +143,16 @@ def test_bad_stream():
         vobject.base.readOne(bad_stream)
 
 
+def test_empty_stream():
+    """
+    An empty or whitespace-only stream has no components and used to raise a
+    bare StopIteration; it should raise ParseError.
+    """
+    for stream in ("", "   ", "\n\n\t"):
+        with pytest.raises(vobject.base.ParseError):
+            vobject.base.readOne(stream)
+
+
 def test_bad_line():
     """
     Test bad line in ics file

--- a/vobject/base.py
+++ b/vobject/base.py
@@ -1122,7 +1122,12 @@ def readOne(stream, validate=False, transform=True, ignoreUnreadable=False, allo
     """
     Return the first component from stream.
     """
-    return next(readComponents(stream, validate, transform, ignoreUnreadable, allowQP))
+    try:
+        return next(readComponents(stream, validate, transform, ignoreUnreadable, allowQP))
+    except StopIteration:
+        # An empty (or whitespace-only) stream yields no components; report it
+        # as a parse error instead of letting a bare StopIteration escape.
+        raise ParseError("No components in stream")
 
 
 # --------------------------- version registry ---------------------------------


### PR DESCRIPTION
`vobject.readOne('')` (or any whitespace-only input) raises a bare `StopIteration` instead of a `ParseError`:

```python
import vobject
vobject.readOne('')
# StopIteration
```

`readOne` returns `next(readComponents(...))`, and an empty or whitespace-only stream yields no components, so `next()` raises `StopIteration` straight out of `readOne`. I catch it and raise `ParseError` instead, consistent with how the other malformed-input cases are reported.

Added a `test_empty_stream` next to `test_bad_stream`; it raises StopIteration on `master` and passes with the change, and the parsing suite still passes. Found it by fuzzing `readOne`.